### PR TITLE
feat(caching): set cache-control header to not cache anything for now

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,8 @@
 import express from 'express';
-import { disallowInProduction, security } from './middleware.js';
 import compression from 'compression';
 import favicon from 'serve-favicon';
+
+import { doNotCache, disallowInProduction, security } from './middleware.js';
 import { catchRejections } from './helpers.js';
 
 import { controller as catchErrors } from './pages/error-catch-all.js';
@@ -18,7 +19,11 @@ const app = express();
 app.use(security);
 app.use(compression());
 app.use(favicon('public/favicon.ico'));
+// express.static needs to be called *before* setting a
+// general Cache-Control header, otherwise express.static
+// cache options are ignored
 app.use(express.static('public', { maxAge: '1 day' }));
+app.use(doNotCache);
 
 app.get('/', catchRejections(home));
 app.post(

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -310,6 +310,46 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		});
 	});
 
+	describe('Caching', () => {
+		it('sets a no-cache header for the homepage', async () => {
+			const { headers, status } = await request.get('/');
+			expect(status).toBe(200);
+			expect(headers['cache-control']).toEqual(
+				'no-store, no-cache, must-revalidate, proxy-revalidate'
+			);
+		});
+
+		it('sets a no-cache header for the share page', async () => {
+			nock(config.API_URL).get('/games/00000').reply(200, newGame);
+			const { headers, status } = await request.get(
+				'/games/00000/share?players=11111,22222&choice=11111'
+			);
+			expect(status).toBe(200);
+			expect(headers['cache-control']).toEqual(
+				'no-store, no-cache, must-revalidate, proxy-revalidate'
+			);
+		});
+
+		it('sets a no-cache header for game pages', async () => {
+			nock(config.API_URL).get('/games/00000').reply(200, newGame);
+			const { headers, status } = await request.get(
+				'/games/00000?player=11111'
+			);
+			expect(status).toBe(200);
+			expect(headers['cache-control']).toEqual(
+				'no-store, no-cache, must-revalidate, proxy-revalidate'
+			);
+		});
+
+		it('sets a no-cache header for 4xx/5xx pages', async () => {
+			const { headers, status } = await request.get('/made-up-path');
+			expect(status).toBe(404);
+			expect(headers['cache-control']).toEqual(
+				'no-store, no-cache, must-revalidate, proxy-revalidate'
+			);
+		});
+	});
+
 	describe('Not found page', () => {
 		/**
 		 * @type {supertest.Response}

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -5,6 +5,22 @@ import { HttpError } from './helpers.js';
 
 /**
  * @param {ExpressRequest} _req
+ * @param {ExpressResponse} res
+ * @param {NextFunction} next
+ */
+export const doNotCache = (_req, res, next) => {
+	res.setHeader(
+		'Cache-Control',
+		'no-store, no-cache, must-revalidate, proxy-revalidate'
+	);
+	res.setHeader('Pragma', 'no-cache');
+	res.setHeader('Expires', '0');
+
+	next();
+};
+
+/**
+ * @param {ExpressRequest} _req
  * @param {ExpressResponse} _res
  * @param {NextFunction} next
  */


### PR DESCRIPTION
I’m playing around with a CDN for fun, so will add some caching at some point but for now, let’s be explicit about not wanting anything to be cached.