### PR TITLE
perf: tweak caching

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -21,6 +21,8 @@ import { read as apiRead, update as apiUpdate } from './pages/api-proxy.js';
 
 const app = express();
 
+app.set('etag', false);
+
 app.use(security);
 app.use(compression());
 app.use(favicon('public/favicon.ico'));

--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,12 @@ import express from 'express';
 import compression from 'compression';
 import favicon from 'serve-favicon';
 
-import { doNotCache, disallowInProduction, security } from './middleware.js';
+import {
+	cacheFor,
+	doNotCache,
+	disallowInProduction,
+	security
+} from './middleware.js';
 import { catchRejections } from './helpers.js';
 
 import { controller as catchErrors } from './pages/error-catch-all.js';
@@ -25,7 +30,7 @@ app.use(favicon('public/favicon.ico'));
 app.use(express.static('public', { maxAge: '1 day' }));
 app.use(doNotCache);
 
-app.get('/', catchRejections(home));
+app.get('/', cacheFor(60 * 60 * 24), catchRejections(home));
 app.post(
 	'/games',
 	express.urlencoded({ extended: false }),

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -314,9 +314,7 @@ describe(`The ${config.APP_FRIENDLY_NAME} app`, () => {
 		it('sets a no-cache header for the homepage', async () => {
 			const { headers, status } = await request.get('/');
 			expect(status).toBe(200);
-			expect(headers['cache-control']).toEqual(
-				'no-store, no-cache, must-revalidate, proxy-revalidate'
-			);
+			expect(headers['cache-control']).toEqual('public, max-age=86400');
 		});
 
 		it('sets a no-cache header for the share page', async () => {

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -20,6 +20,27 @@ export const doNotCache = (_req, res, next) => {
 };
 
 /**
+ * @param {number} maxAge
+ * @param {object} [options]
+ * @param {boolean} [options.isPrivate]
+ */
+export const cacheFor = (maxAge, { isPrivate = false } = {}) => {
+	/**
+	 * @param {ExpressRequest} _req
+	 * @param {ExpressResponse} res
+	 * @param {NextFunction} next
+	 */
+	return (_req, res, next) => {
+		res.setHeader(
+			'Cache-Control',
+			`${isPrivate ? 'private' : 'public'}, max-age=${maxAge}`
+		);
+
+		next();
+	};
+};
+
+/**
  * @param {ExpressRequest} _req
  * @param {ExpressResponse} _res
  * @param {NextFunction} next


### PR DESCRIPTION
- [perf: cache the homepage for a day (max)](https://github.com/leafrogers/tic-tac-toe-ui/commit/cb21b2fbdc6ca28ad473725a3afe5fedeade3b97)

There doesn’t seem to be any harm™️ in caching the homepage, because it doesn’t have anything dynamic in it.

- [perf: turn-off etag caching](https://github.com/leafrogers/tic-tac-toe-ui/commit/d28372b8447d4df459c08d1195fa95248e7fb42a)

We’re using a CDN for caching now so we may as well turn this off, and
stop the server from generating etag hashes for each request.